### PR TITLE
Filtrar pares

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ A função **`ordemCrescente`** é responsável por ordenar um vetor de números
 ```rust
 fn ordemCrescente(lista: &mut Vec<i64>)
 ```
+
+### 2. `filtrar_pares` (Filtragem de números pares únicos)
+
+A função **`filtrar_pares`** recebe um vetor mutável de inteiros e filtra apenas os números pares. O vetor é modificado in-place para conter apenas os valores pares distintos.
+
+**Assinatura:**
+
+```rust
+fn filtrar_pares(lista: &mut Vec<i64>)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,14 @@
+fn ordemCrescente(lista: &mut Vec<i64>) {
+    let n = lista.len();
+    for i in 1..n {
+        let mut j = i;
+        while j > 0 && lista[j - 1] > lista[j] {
+            lista.swap(j, j - 1);
+            j -= 1;
+        }
+    }
+}
+
 fn filtrar_pares(vetor: &mut Vec<i64>) {
     let mut pares = Vec::new();
 
@@ -16,8 +27,9 @@ fn executar_estrategia(lista: &mut Vec<i64>, estrategia: fn(&mut Vec<i64>)) {
 }
 
 fn main() {
-    let mut numeros : Vec<i64> = vec![5, 2, 8, 5, 2, 9, 1, 0, 4, 4];
+    let mut numeros : Vec<i64> = vec![5, 5, 1, 0, 9, 8, 6, 2, 8, 5, 2, 9, 1, 0, 4, 4];
     println!("Lista original: {:?}", numeros);
+    executar_estrategia(&mut numeros, ordemCrescente);
     executar_estrategia(&mut numeros, filtrar_pares);
-    
+
 }


### PR DESCRIPTION
# Implementa função `filtrar_pares`

Basicamente, a função de filtrar pares recebe um parâmetro vetor, que é uma referência mutável para o vetor criado na main. Dentro da função, criei a variável pares que vai receber apenas os números pares dentro do laço que itera por todo o vetor principal. Após o laço ser finalizado, é possível garantir que pares contém apenas os valores mencionados, na ordem e na quantidade de vezes que aparecem Fazemos o ponteiro para o vetor principal receber esse outro vetor pares, para que o vetor principal fique atualizado.

## 📌 Exemplo de uso

```rust
let numeros = vec![5, 5, 1, 0, 9, 8, 6, 2, 8, 5, 2, 9, 1, 0, 4, 4];
    println!("Lista original: {:?}", numeros);

    executar_estrategia(numeros, filtrar_pares);
// Agora `numeros` será: [0, 8, 6, 2, 8, 2, 0, 4, 4]
