### PR TITLE
Add função removeDuplicatas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ A função **`ordena_decrescente`** é responsável por ordenar um vetor de núm
 ```rust
 fn ordena_decrescente(lista: &mut Vec<i64>)
 ```
+### 3. `removeDuplicatas` 
+A função **`removeDuplicatas`** implementa um algoritmo eficiente para remover elementos duplicados de um vetor (Vec<i64>), preservando a ordem da primeira aparição de cada elemento. Para garantir um desempenho otimizado, a função emprega um HashSet para rastrear os valores já vistos. A remoção dos itens é realizada através do método "retain", que avalia cada elemento e o mantém apenas se for a primeira vez que ele é encontrado.
 
+**Assinatura:**
+```rust
+fn removeDuplicatas(lista: &mut Vec<i64>)
+```
 ### 4. `filtrar_pares` (Filtragem de números pares)
 
 A função **`filtrar_pares`** recebe um vetor mutável de inteiros e filtra apenas os números pares. O vetor é modificado in-place para conter apenas os valores pares distintos.

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,15 @@ fn ordemCrescente(lista: &mut Vec<i64>) {
     }
 }
 
+use std::collections::HashSet;//para remover duplicatas
+fn removeDuplicatas(lista: &mut Vec<i64>) {
+    // 1. Cria um HashSet para rastrear os elementos que já vimos.
+    let mut vistos = HashSet::new();
+
+    // 2. Usa o método `retain` para manter apenas os elementos únicos.
+    lista.retain(|elemento| vistos.insert(*elemento));
+}
+
 fn filtrar_pares(vetor: &mut Vec<i64>) {
     let mut pares = Vec::new();
 
@@ -44,5 +53,6 @@ fn main() {
     executar_estrategia(&mut numeros, ordemCrescente);
     executar_estrategia(&mut numeros, ordena_decrescente);
     executar_estrategia(&mut numeros, filtrar_pares);
+    executar_estrategia(&mut numeros,removeDuplicatas);
 
 }


### PR DESCRIPTION
# Implementa função removeDuplicatas
Esta função remove elementos duplicados de um vetor de inteiros (Vec<i64>). Ela opera in-place, ou seja, modifica o vetor original diretamente em vez de criar um novo. A ordem da primeira ocorrência de cada elemento é preservada. Para garantir a eficiência, a função utiliza um HashSet para rastrear os números que já foram vistos, permitindo a verificação de duplicatas em tempo médio constante, O(1). O método retain itera sobre o vetor, mantendo um elemento apenas se ele for inserido com sucesso no HashSet (o que só acontece na primeira vez que ele é encontrado).

## 📌 Exemplo de uso

```rust
let mut numeros = vec![10, 2, 5, 2, 8, 10, 5, 9];
    println!("Lista original: {:?}", numeros);

    executar_estrategia(numeros, removeDuplicatas);
// Agora numeros será: [10, 2, 5, 8, 9]